### PR TITLE
paypal added on front end

### DIFF
--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -26,7 +26,7 @@ router.route("/mine").get(protect, getMyOrders);
 router.route("/:id").get(protect, getOrderByID);
 
 // Update order to paid
-router.route("/:id/paid").put(protect, protectAdmin, UpdateOrderToPaid);
+router.route("/:id/pay").put(protect, UpdateOrderToPaid);
 
 //Update order to delivered
 router

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -12,7 +12,7 @@ import store from "./store";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <PayPalScriptProvider deferLoading={true}>
+    <PayPalScriptProvider deferLoading={false}>
       <Provider store={store}>
         <App />
       </Provider>


### PR DESCRIPTION
Added paypal to front end for payment. Now users are able to pay by entering their card information and pressing on the pay button.      

This sends a request to the 'pay' route which updates the order to paid. If an error occurs then an error message is shown. 

I have also added a test payment button, which only updates the isPaid to true, and is there for testing purposes only. 

If successful the `createOrder` function will be created to make a PayPal order with the purchase amount, and update it on the paypal account. 

Both the paypal account and the order page will be updated to reflect any changes. 

This will enhance the user experience by allowing seamless PayPal payments. Payment success and errors are also handled gracefully.


